### PR TITLE
COP-3743 Update aws-secret-key variable

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -95,10 +95,10 @@ aws:
     endpoint:  ${aws.elasticsearch.endpoint:}
     credentials:
       access-key: ${aws.elasticsearch.credentials.access-key:}
-      secret-key: ${aws.elasticsearch.credentials.access-key:}
+      secret-key: ${aws.elasticsearch.credentials.secret-key:}
   credentials:
     access-key: ${AWS_ACCESS_KEY:}
-    secret-Key: ${AWS_SECRET_KEY:}
+    secret-key: ${AWS_SECRET_KEY:}
 
 plugin.identity.keycloak:
   keycloakIssuerUrl: ${keycloak.auth.url}/auth/realms/${keycloak.realm}


### PR DESCRIPTION
Forms were not being written to S3 due to the secret key calling the access-key variable.
This PR updates it to call the secret-key variable.

**To test**

- submit a collect-event-at-border form
>- form should successfully submit and show confirmation message
>- cop-service logs should show last log with `message":"Saved form data` in it