### PR TITLE
COP-4281 Add ProcessStartDelegate class

### DIFF
--- a/src/main/java/uk/gov/homeoffice/borders/workflow/process/ProcessStartDelegate.java
+++ b/src/main/java/uk/gov/homeoffice/borders/workflow/process/ProcessStartDelegate.java
@@ -1,0 +1,36 @@
+package uk.gov.homeoffice.borders.workflow.process;
+
+import lombok.extern.slf4j.Slf4j;
+import org.camunda.bpm.engine.delegate.BpmnError;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.JavaDelegate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class ProcessStartDelegate implements JavaDelegate {
+
+    @Override
+    public void execute(DelegateExecution execution) {
+        try {
+
+            Object payload = execution.getVariable("payload");
+            String variableName = execution.getVariable("variableName").toString();
+            String businessKey = execution.getVariable("businessKey").toString();
+            String processKey = execution.getVariable("processKey").toString();
+
+            execution.getProcessEngineServices()
+                    .getRuntimeService()
+                    .createProcessInstanceByKey(processKey)
+                    .businessKey(businessKey)
+                    .setVariable("type", "non-notification")
+                    .setVariable(variableName, payload)
+                    .execute();
+
+        } catch (Exception e) {
+            log.error("Failed to start workflow", e);
+            throw new BpmnError("FAILED_TO_START_EVENT", e.getMessage());
+        }
+
+    }
+}


### PR DESCRIPTION
When a process instance reaches the `Trigger handle workflow` task in the `collect-event-at-border.bpmn` an incident occurs noting `ProcessStartDelegate` as being undefined. This class is used across several bpmns.

`ProcessStartDelegate` has been added in order to prevent this error and allow process instances to progress through bpmns successfully. `package` has been set to `uk.gov.homeoffice.borders.workflow.process` in order to reflect it's location in `workflow-service` and to align with bpmns that reference the `ProcessStartDelegate` class. 
