### PR TITLE
Flitering resulting instances by candiate role and group

### DIFF
--- a/src/main/java/io/digital/patterns/workflow/cases/CasesApplicationService.java
+++ b/src/main/java/io/digital/patterns/workflow/cases/CasesApplicationService.java
@@ -111,7 +111,9 @@ public class CasesApplicationService {
                 historicProcessInstances.addAll(instances);
             }
             Map<String, List<HistoricProcessInstance>> groupedByBusinessKey = historicProcessInstances
-                    .stream().collect(Collectors.groupingBy(HistoricProcessInstance::getBusinessKey));
+                    .stream()
+                    .filter(instance -> this.candidateGroupFilter(instance, platformUser))
+                    .collect(Collectors.groupingBy(HistoricProcessInstance::getBusinessKey));
 
             List<Case> cases = groupedByBusinessKey.keySet().stream().map(key -> {
                 Case caseDto = new Case();


### PR DESCRIPTION
GIVEN I belong to the xxxxxx role group
WHEN I search for something that is part of an xxxxxxx or xxxxxxxxx
THEN I should see the search results and be able to access the data

GIVEN I do not belong to the xxxxx role group
WHEN I search for something that is part of an xxxxxx or xxxxxxxx
THEN I should not see the search results and not be able to access the data